### PR TITLE
examples: adapt yamls to new namespace

### DIFF
--- a/examples/mypvc1-smb.yml
+++ b/examples/mypvc1-smb.yml
@@ -1,4 +1,4 @@
-apiVersion: smbservice.samba.org/v1alpha1
+apiVersion: samba-operator.samba.org/v1alpha1
 kind: SmbService
 metadata:
   name: "mypvc1-smb"

--- a/examples/mysmbservice.yml
+++ b/examples/mysmbservice.yml
@@ -1,4 +1,4 @@
-apiVersion: smbservice.samba.org/v1alpha1
+apiVersion: samba-operator.samba.org/v1alpha1
 kind: SmbService
 metadata:
   name: "smb-mypvc"

--- a/examples/smbpvc1.yml
+++ b/examples/smbpvc1.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: smbpvc.samba.org/v1alpha1
+apiVersion: samba-operator.samba.org/v1alpha1
 kind: SmbPvc
 metadata:
   name: "mysmbpvc1"

--- a/examples/smbservice-with-mypvc2.yml
+++ b/examples/smbservice-with-mypvc2.yml
@@ -10,7 +10,7 @@ spec:
       storage: 2Mi
   storageClassName: glusterfile
 ---
-apiVersion: smbservice.samba.org/v1alpha1
+apiVersion: samba-operator.samba.org/v1alpha1
 kind: SmbService
 metadata:
   name: "mypvc2-smb"


### PR DESCRIPTION
Adapt examples for new namespace `samba-operator.samba.org` instead of `smbservice.samba.org` and `smbpvc.sam