### PR TITLE
Add check rules to the makefile

### DIFF
--- a/.revive.toml
+++ b/.revive.toml
@@ -1,0 +1,49 @@
+
+ignoreGeneratedHeader = false
+severity = "error"
+confidence = 0.8
+errorCode = 1
+warningCode = 0
+
+[directive.specify-disable-reason]
+
+[rule.blank-imports]
+[rule.context-as-argument]
+[rule.context-keys-type]
+[rule.dot-imports]
+[rule.error-return]
+[rule.error-strings]
+[rule.error-naming]
+[rule.exported]
+[rule.if-return]
+[rule.increment-decrement]
+# TODO: make this rule live once code is fixed up (other PR)
+#[rule.var-naming]
+[rule.var-declaration]
+[rule.package-comments]
+[rule.range]
+[rule.receiver-naming]
+[rule.time-naming]
+[rule.unexported-return]
+[rule.indent-error-flow]
+[rule.errorf]
+[rule.empty-block]
+[rule.superfluous-else]
+[rule.unused-parameter]
+[rule.unreachable-code]
+[rule.redefines-builtin-id]
+
+[rule.atomic]
+[rule.bool-literal-in-expr]
+[rule.constant-logical-expr]
+[rule.unnecessary-stmt]
+[rule.unused-receiver]
+
+[rule.argument-limit]
+  arguments = [7]
+[rule.function-result-limit]
+  arguments = [3]
+
+[rule.unhandled-error]
+  # functions to ignore unhandled errors on
+  arguments = ["fmt.Printf", "fmt.Println"]

--- a/controllers/smbpvc_controller.go
+++ b/controllers/smbpvc_controller.go
@@ -56,6 +56,7 @@ func (r *SmbPvcReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	return ctrl.Result{}, err
 }
 
+// SetupWithManager sets up resource management.
 func (r *SmbPvcReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&sambaoperatorv1alpha1.SmbPvc{}).

--- a/controllers/smbservice_controller.go
+++ b/controllers/smbservice_controller.go
@@ -41,6 +41,7 @@ type SmbServiceReconciler struct {
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list
 
+// Reconcile resources.
 func (r *SmbServiceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	ctx := context.Background()
 	reqLogger := r.Log.WithValues("smbservice", req.NamespacedName)
@@ -55,6 +56,7 @@ func (r *SmbServiceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) 
 	return ctrl.Result{}, err
 }
 
+// SetupWithManager sets up resource management.
 func (r *SmbServiceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&sambaoperatorv1alpha1.SmbService{}).

--- a/internal/resources/smbpvc.go
+++ b/internal/resources/smbpvc.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-// SmbServiceManager is used to manage SmbService resources.
+// SmbPvcManager is used to manage SmbService resources.
 type SmbPvcManager struct {
 	client client.Client
 	scheme *runtime.Scheme
@@ -45,6 +45,7 @@ func NewSmbPvcManager(client client.Client, scheme *runtime.Scheme, logger Logge
 	}
 }
 
+// Update the managed resources on CR change.
 func (m *SmbPvcManager) Update(ctx context.Context, nsname types.NamespacedName) Result {
 	// Fetch the SmbPvc instance
 	instance := &sambaoperatorv1alpha1.SmbPvc{}


### PR DESCRIPTION
Currently checks entail gofmt and [revive](https://github.com/mgechev/revive) tools.

After this is merged we can use it to set up some simple CI tests for building and checks.