### PR TITLE
makefile: try to force use of shell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ check-revive: revive
 	$(REVIVE) -config .revive.toml $$(go list ./... | grep -v /vendor/)
 
 revive:
-ifeq (, $(shell command -v revive))
+ifeq (, $(shell command -v revive ;))
 	@{ \
 	set -e ;\
 	REVIVE_TMP_DIR=$$(mktemp -d) ;\


### PR DESCRIPTION
Currently the CI is not properly handling command -v, as make bypasses
the shell.
See also:
https://stackoverflow.com/questions/5618615/check-if-a-program-exists-from-a-makefile

Signed-off-by: John Mulligan <jmulligan@redhat.com>