### PR TITLE
Rework revive detection and installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,17 +148,22 @@ check-revive: revive
 
 revive:
 ifeq (, $(shell command -v revive ;))
+	@echo "revive not found in PATH, checking in GOBIN ($(GOBIN))..."
 ifeq (, $(shell command -v $(GOBIN)/revive ;))
 	@{ \
 	set -e ;\
+	echo "revive not found in GOBIN, getting revive..." ;\
 	REVIVE_TMP_DIR=$$(mktemp -d) ;\
 	cd $$REVIVE_TMP_DIR ;\
 	go mod init tmp ;\
 	go get  github.com/mgechev/revive  ;\
 	rm -rf $$REVIVE_TMP_DIR ;\
 	}
+else
+	@echo "revive found in GOBIN"
 endif
 REVIVE:=$(shell command -v $(GOBIN)/revive ;)
 else
+	@echo "revive found in PATH"
 REVIVE:=$(shell command -v revive ;)
 endif

--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ check-revive: revive
 	$(REVIVE) -config .revive.toml $$(go list ./... | grep -v /vendor/)
 
 revive:
-ifeq (, $(shell command -v revive))
+ifeq (, $(shell command -v revive ;))
 	@{ \
 	set -e ;\
 	REVIVE_TMP_DIR=$$(mktemp -d) ;\

--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,7 @@ check-revive: revive
 
 revive:
 ifeq (, $(shell command -v revive ;))
+ifeq (, $(shell command -v $(GOBIN)/revive ;))
 	@{ \
 	set -e ;\
 	REVIVE_TMP_DIR=$$(mktemp -d) ;\
@@ -156,7 +157,8 @@ ifeq (, $(shell command -v revive ;))
 	go get  github.com/mgechev/revive  ;\
 	rm -rf $$REVIVE_TMP_DIR ;\
 	}
-REVIVE:=$(GOBIN)/revive
+endif
+REVIVE:=$(shell command -v $(GOBIN)/revive ;)
 else
-REVIVE:=$(shell command -v revive)
+REVIVE:=$(shell command -v revive ;)
 endif

--- a/Makefile
+++ b/Makefile
@@ -146,6 +146,7 @@ check-revive: revive
 	# See: https://github.com/mgechev/revive
 	$(REVIVE) -config .revive.toml $$(go list ./... | grep -v /vendor/)
 
+.PHONY: revive
 revive:
 ifeq (, $(shell command -v revive ;))
 	@echo "revive not found in PATH, checking in GOBIN ($(GOBIN))..."


### PR DESCRIPTION
- include the trick from #13 to make gnu make invoke the shell by adding `;`
- first check revive in path, then in GOBIN, as last resort, download.
- add informational messages (can be skipped if not desired)
- make revive PHONY
