### PR TITLE
resources: don't expose 139 as a container port

### DIFF
--- a/internal/resources/smbservice.go
+++ b/internal/resources/smbservice.go
@@ -137,9 +137,6 @@ func (m *SmbServiceManager) deploymentForSmbService(s *sambaoperatorv1alpha1.Smb
 						Name:  cfg.SmbdContainerName,
 						//NEEDED? - Command: []string{"cmd", "arg", "arg", "..."},
 						Ports: []corev1.ContainerPort{{
-							ContainerPort: 139,
-							Name:          "smb-netbios",
-						}, {
 							ContainerPort: 445,
 							Name:          "smb",
 						}},


### PR DESCRIPTION
Port 139 is fairly obsolete and we shouldn't needed for our
use cases.

Fixes: #10 