### PR TITLE
Makefile: make command detection more portable (and silent)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ container-push:
 # find or download controller-gen
 # download controller-gen if necessary
 controller-gen:
-ifeq (, $(shell which controller-gen))
+ifeq (, $(shell command -v controller-gen ;))
 	@{ \
 	set -e ;\
 	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
@@ -103,11 +103,11 @@ ifeq (, $(shell which controller-gen))
 	}
 CONTROLLER_GEN=$(GOBIN)/controller-gen
 else
-CONTROLLER_GEN=$(shell which controller-gen)
+CONTROLLER_GEN=$(shell command -v controller-gen ;)
 endif
 
 kustomize:
-ifeq (, $(shell which kustomize))
+ifeq (, $(shell command -v kustomize ;))
 	@{ \
 	set -e ;\
 	KUSTOMIZE_GEN_TMP_DIR=$$(mktemp -d) ;\
@@ -118,7 +118,7 @@ ifeq (, $(shell which kustomize))
 	}
 KUSTOMIZE=$(GOBIN)/kustomize
 else
-KUSTOMIZE=$(shell which kustomize)
+KUSTOMIZE=$(shell command -v kustomize ;)
 endif
 
 # Generate bundle manifests and metadata, then validate generated files.


### PR DESCRIPTION
Use `command -v` instead of `which`. `command` is POSIX.
which is does not have universal behavior.

On my machine, it creates noisy output like this.

```
which: no controller-gen in (/usr/lib64/qt-3.3/bin:/usr/share/Modules/bin:/usr/lib64/ccache:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/home/obnox/.local/bin:/home/obnox/bin:/home/obnox/.local/bin:/home/obnox/bin)
which: no kustomize in (/usr/lib64/qt-3.3/bin:/usr/share/Modules/bin:/usr/lib64/ccache:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/home/obnox/.local/bin:/home/obnox/bin:/home/obnox/.local/bin:/home/obnox/bin)
```

Note: the semicolon at the end is added to circumvent GNU make's
optimization of omitting the shell invocation if the command looks
simple enough... "command" is often a shell builtin and not a binary.

Signed-off-by: Michael Adam <obnox@samba.org>