### PR TITLE
Fix revive detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,7 @@ ifeq (, $(shell command -v $(GOBIN)/revive ;))
 	go get  github.com/mgechev/revive  ;\
 	rm -rf $$REVIVE_TMP_DIR ;\
 	}
+	@echo "revive installed in GOBIN"
 else
 	@echo "revive found in GOBIN"
 endif

--- a/Makefile
+++ b/Makefile
@@ -163,8 +163,8 @@ ifeq (, $(shell command -v $(GOBIN)/revive ;))
 else
 	@echo "revive found in GOBIN"
 endif
-REVIVE:=$(shell command -v $(GOBIN)/revive ;)
+REVIVE=$(shell command -v $(GOBIN)/revive ;)
 else
 	@echo "revive found in PATH"
-REVIVE:=$(shell command -v revive ;)
+REVIVE=$(shell command -v revive ;)
 endif


### PR DESCRIPTION
There was an error in revive detection. If revive was installed by make, the variable REVIVE was not set correctly due to simple variable assignment. Recursive assignment fixes this.